### PR TITLE
Remove repeated and no need it code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,6 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "spatie/laravel-package-tools": "^1.1",
-        "illuminate/contracts": "^8.0",
         "tipoff/support": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
- remove `php`, `spatie/laravel-package-tools`, `illuminate/contracts` that are called in `tipoff/support`