### PR TITLE
Feedback Email Commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
     "require": {
         "php": "^7.3|^8.0",
         "tipoff/authorization": "^1.0.1",
+        "tipoff/escape-room": "^1.1",
+        "tipoff/locations": "^2.0",
         "tipoff/support": "^1.3.0"
     },
     "require-dev": {

--- a/database/factories/FeedbackFactory.php
+++ b/database/factories/FeedbackFactory.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 declare(strict_types=1);
 
@@ -6,7 +6,9 @@ namespace Tipoff\Feedback\Database\Factories;
 
 use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Tipoff\EscapeRoom\Models\Participant;
 use Tipoff\Feedback\Models\Feedback;
+use Tipoff\Locations\Models\Location;
 
 class FeedbackFactory extends Factory
 {
@@ -108,8 +110,8 @@ class FeedbackFactory extends Factory
         }
 
         return [
-            'participant_id'            => randomOrCreate(app('participant')),
-            'location_id'               => randomOrCreate(app('location')),
+            'participant_id'            => randomOrCreate(Participant::class),
+            'location_id'               => randomOrCreate(Location::class),
             'date'                      => $this->faker->date(), // Should be a day less than emailed_at
             'emailed_at'                => $this->faker->dateTimeBetween('-3 months', '-1 months'),
             'email_identifier'          => Str::random(100),

--- a/database/migrations/2020_05_11_130000_create_feedbacks_table.php
+++ b/database/migrations/2020_05_11_130000_create_feedbacks_table.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Tipoff\EscapeRoom\Models\Participant;
+use Tipoff\Locations\Models\Location;
 
 class CreateFeedbacksTable extends Migration
 {
@@ -13,8 +15,8 @@ class CreateFeedbacksTable extends Migration
         Schema::create('feedbacks', function (Blueprint $table) {
             $table->id();
             $table->string('token')->index()->unique(); // unique hash for the feedback so can use in links instead of the id
-            $table->foreignIdFor(app('participant'))->index();
-            $table->foreignIdFor(app('location'))->index();
+            $table->foreignIdFor(Participant::class)->index();
+            $table->foreignIdFor(Location::class)->index();
             $table->date('date')->index(); // date the escape room game was played
             $table->dateTime('emailed_at')->nullable();
             $table->string('email_identifier')->nullable()->unique(); // "MessageID" from Postmark or email service needed to track opens since multiple feedbacks could exist and can't track opens to the participant

--- a/resources/views/emails/request.blade.php
+++ b/resources/views/emails/request.blade.php
@@ -1,0 +1,14 @@
+@component('mail::message')
+    Hi {{ $name }},
+
+    Win a $250 Amazon gift card and free tickets to The Great Escape Room by providing feedback below. We hope you had a great time!
+
+    Please click a face below to provide feedback:
+
+    @component('mail::rate', ['negative' => $negative, 'seminegative' => $seminegative, 'semipositive' => $semipositive, 'positive' => $positive])
+    @endcomponent
+
+    Thank you,
+
+    Kirk Eppenstein, COO
+@endcomponent

--- a/resources/views/emails/summary.blade.php
+++ b/resources/views/emails/summary.blade.php
@@ -1,0 +1,12 @@
+@component('mail::message')
+    # Introduction
+
+    The body of your message.
+
+    @component('mail::button', ['url' => ''])
+        Button Text
+    @endcomponent
+
+    Thanks,<br>
+    {{ config('app.name') }}
+@endcomponent

--- a/src/Commands/SendFeedbackRequestEmails.php
+++ b/src/Commands/SendFeedbackRequestEmails.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Feedback\Commands;
+
+use Tipoff\Feedback\Mail\FeedbackRequest;
+use Tipoff\Feedback\Models\Feedback;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendFeedbackRequestEmails extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send:feedbackrequest';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send emails to participants requesting feedback';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Will need to limit. Will also just want yesterday's participants.
+        $today = Carbon::now('America/New_York')->format('Y-m-d');
+        $feedbacks = Feedback::whereNull('emailed_at')
+            ->where('date', '<', $today)
+            ->orderByDesc('id')
+            ->take(10)
+            ->get();
+        foreach ($feedbacks as $feedback) {
+            Mail::send(new FeedbackRequest($feedback));
+
+            // This is needed to prevent emailing twice. Can update later to the actual time the email was sent if need to be exact and confirm it was actually sent.
+            $feedback->emailed_at = Carbon::now();
+            $feedback->save();
+        }
+    }
+}

--- a/src/Commands/SendFeedbackRequestEmails.php
+++ b/src/Commands/SendFeedbackRequestEmails.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Tipoff\Feedback\Commands;
 
-use Tipoff\Feedback\Mail\FeedbackRequest;
-use Tipoff\Feedback\Models\Feedback;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
+use Tipoff\Feedback\Mail\FeedbackRequest;
+use Tipoff\Feedback\Models\Feedback;
 
 class SendFeedbackRequestEmails extends Command
 {

--- a/src/Commands/SendFeedbackSummaryEmails.php
+++ b/src/Commands/SendFeedbackSummaryEmails.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tipoff\Feedback\Commands;
 
-use Tipoff\Feedback\Mail\FeedbackSummary;
-use Tipoff\Locations\Models\Location;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
+use Tipoff\Feedback\Mail\FeedbackSummary;
+use Tipoff\Locations\Models\Location;
 
 class SendFeedbackSummaryEmails extends Command
 {

--- a/src/Commands/SendFeedbackSummaryEmails.php
+++ b/src/Commands/SendFeedbackSummaryEmails.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Feedback\Commands;
+
+use Tipoff\Feedback\Mail\FeedbackSummary;
+use Tipoff\Locations\Models\Location;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendFeedbackSummaryEmails extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'send:feedbacksummary';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Send the daily summary emails of the new internal feedback we received';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // Check if there is any new internal feedback or Google Reviews
+        $locations = Location::where('corporate', 1)->get();
+        foreach ($locations as $location) {
+            Mail::send(new FeedbackSummary($location));
+        }
+    }
+}

--- a/src/FeedbackServiceProvider.php
+++ b/src/FeedbackServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tipoff\Feedback;
 
+use Tipoff\Feedback\Commands\SendFeedbackRequestEmails;
+use Tipoff\Feedback\Commands\SendFeedbackSummaryEmails;
 use Tipoff\Feedback\Models\Feedback;
 use Tipoff\Feedback\Policies\FeedbackPolicy;
 use Tipoff\Support\TipoffPackage;
@@ -17,7 +19,12 @@ class FeedbackServiceProvider extends TipoffServiceProvider
             ->hasPolicies([
                 Feedback::class => FeedbackPolicy::class,
             ])
+            ->hasCommands([
+                SendFeedbackRequestEmails::class,
+                SendFeedbackSummaryEmails::class,
+            ])
             ->name('feedback')
+            ->hasViews()
             ->hasConfigFile();
     }
 }

--- a/src/Mail/FeedbackRequest.php
+++ b/src/Mail/FeedbackRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Feedback\Mail;
+
+use Tipoff\Feedback\Models\Feedback;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class FeedbackRequest extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $feedback;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param Feedback $feedback
+     */
+    public function __construct(Feedback $feedback)
+    {
+        $this->feedback = $feedback;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $feedback = $this->feedback;
+        $negative = url('/feedback/response?token=' . $feedback->token . '&rating=negative');
+        $seminegative = url('/feedback/response?token=' . $feedback->token . '&rating=seminegative');
+        $semipositive = url('/feedback/response?token=' . $feedback->token . '&rating=semipositive');
+        $positive = url('/feedback/response?token=' . $feedback->token . '&rating=positive');
+
+        $this->withSwiftMessage(function ($message) use ($feedback) {
+            $message->feedback = $feedback;
+            $message->getHeaders()->addTextHeader('tag', 'feedback');
+        });
+
+        return $this->markdown('feedback::emails.request')
+            ->from($feedback->location->contact_email, $feedback->location->title)
+            ->to($feedback->participant->email)
+            ->bcc('digitalmgr@thegreatescaperoom.com')
+            ->subject('How was your experience on ' . Carbon::parse($feedback->date)->format('M j') . '?')
+            ->with([
+                'name' => $feedback->participant->name,
+                'negative' => $negative,
+                'seminegative' => $seminegative,
+                'semipositive' => $semipositive,
+                'positive' => $positive,
+            ]);
+    }
+}

--- a/src/Mail/FeedbackRequest.php
+++ b/src/Mail/FeedbackRequest.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Tipoff\Feedback\Mail;
 
-use Tipoff\Feedback\Models\Feedback;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Tipoff\Feedback\Models\Feedback;
 
 class FeedbackRequest extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     public $feedback;
 

--- a/src/Mail/FeedbackSummary.php
+++ b/src/Mail/FeedbackSummary.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Feedback\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Tipoff\Locations\Models\Location;
+
+class FeedbackSummary extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $location;
+
+    /**
+     * Create a new message instance.
+     *
+     * @param $location
+     */
+    public function __construct(Location $location)
+    {
+        $this->location = $location;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        // Also need to include the Google Reviews
+        // Include positive/negative count in title
+        return $this->markdown('feedback::emails.summary');
+    }
+}

--- a/src/Mail/FeedbackSummary.php
+++ b/src/Mail/FeedbackSummary.php
@@ -11,7 +11,8 @@ use Tipoff\Locations\Models\Location;
 
 class FeedbackSummary extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable;
+    use SerializesModels;
 
     public $location;
 

--- a/src/Models/Feedback.php
+++ b/src/Models/Feedback.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tipoff\Feedback\Models;
 
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Tipoff\EscapeRoom\Models\Participant;
+use Tipoff\Locations\Models\Location;
 use Tipoff\Support\Models\BaseModel;
 use Tipoff\Support\Traits\HasPackageFactory;
 
@@ -46,11 +48,11 @@ class Feedback extends BaseModel
 
     public function participant()
     {
-        return $this->belongsTo(app('participant'), 'participant_id');
+        return $this->belongsTo(Participant::class);
     }
 
     public function location()
     {
-        return $this->belongsTo(app('location'), 'location_id');
+        return $this->belongsTo(Location::class);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,7 +26,7 @@ class TestCase extends BaseTestCase
             PermissionServiceProvider::class,
             FeedbackServiceProvider::class,
             LocationsServiceProvider::class,
-            EscapeRoomServiceProvider::class
+            EscapeRoomServiceProvider::class,
         ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,8 +7,10 @@ namespace Tipoff\Feedback\Tests;
 use Laravel\Nova\NovaCoreServiceProvider;
 use Spatie\Permission\PermissionServiceProvider;
 use Tipoff\Authorization\AuthorizationServiceProvider;
+use Tipoff\EscapeRoom\EscapeRoomServiceProvider;
 use Tipoff\Feedback\FeedbackServiceProvider;
 use Tipoff\Feedback\Tests\Support\Providers\NovaPackageServiceProvider;
+use Tipoff\Locations\LocationsServiceProvider;
 use Tipoff\Support\SupportServiceProvider;
 use Tipoff\TestSupport\BaseTestCase;
 
@@ -23,6 +25,8 @@ class TestCase extends BaseTestCase
             AuthorizationServiceProvider::class,
             PermissionServiceProvider::class,
             FeedbackServiceProvider::class,
+            LocationsServiceProvider::class,
+            EscapeRoomServiceProvider::class
         ];
     }
 }

--- a/tests/Unit/Mail/FeedbackRequestTest.php
+++ b/tests/Unit/Mail/FeedbackRequestTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Feedback\Tests\Unit\Mail;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
+use Tipoff\Feedback\Mail\FeedbackRequest;
+use Tipoff\Feedback\Models\Feedback;
+use Tipoff\Feedback\Tests\TestCase;
+
+class FeedbackRequestTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    //Todo: Need to figure out how to test markdown content
+    /** @test */
+    public function email()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        $feedback = Feedback::factory()->create();
+        Mail::send(new FeedbackRequest($feedback));
+        Mail::assertSent(function (FeedbackRequest $mail) use ($feedback) {
+            $mail->build();
+            return $mail->feedback->id === $feedback->id &&
+                $mail->hasFrom($feedback->location->contact_email, $feedback->location->title) &&
+                $mail->hasTo($feedback->participant->email) &&
+                $mail->hasBcc('digitalmgr@thegreatescaperoom.com');
+        });
+    }
+}

--- a/tests/Unit/Mail/FeedbackRequestTest.php
+++ b/tests/Unit/Mail/FeedbackRequestTest.php
@@ -15,6 +15,7 @@ class FeedbackRequestTest extends TestCase
     use DatabaseTransactions;
 
     //Todo: Need to figure out how to test markdown content
+
     /** @test */
     public function email()
     {
@@ -25,6 +26,7 @@ class FeedbackRequestTest extends TestCase
         Mail::send(new FeedbackRequest($feedback));
         Mail::assertSent(function (FeedbackRequest $mail) use ($feedback) {
             $mail->build();
+
             return $mail->feedback->id === $feedback->id &&
                 $mail->hasFrom($feedback->location->contact_email, $feedback->location->title) &&
                 $mail->hasTo($feedback->participant->email) &&

--- a/tests/Unit/Mail/FeedbackSummaryTest.php
+++ b/tests/Unit/Mail/FeedbackSummaryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Feedback\Tests\Unit\Mail;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
+use Tipoff\Feedback\Mail\FeedbackSummary;
+use Tipoff\Feedback\Tests\TestCase;
+use Tipoff\Locations\Models\Location;
+
+class FeedbackSummaryTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    //Todo: Need to figure out how to test markdown content
+    /** @test */
+    public function email()
+    {
+        Mail::fake();
+        Mail::assertNothingSent();
+
+        Mail::to('test@example.com')->send(new FeedbackSummary(Location::factory()->create()));
+        Mail::assertSent(FeedbackSummary::class);
+    }
+}

--- a/tests/Unit/Mail/FeedbackSummaryTest.php
+++ b/tests/Unit/Mail/FeedbackSummaryTest.php
@@ -15,6 +15,7 @@ class FeedbackSummaryTest extends TestCase
     use DatabaseTransactions;
 
     //Todo: Need to figure out how to test markdown content
+
     /** @test */
     public function email()
     {


### PR DESCRIPTION
I have added back the commands and functionality associated with them. There are a few points to review:

- Added `tipoff/locations` and `tipoff/escape-room` to account for the Participant and Location models
- Added the `SendFeedbackRequestEmails` and `SendFeedbackSummaryEmails` commands
- Added the `FeedbackRequest` and `FeedbackSummary` Mailables
- Added some basic tests for the new Mailables

While the tests pass, as discussed previously with @drewroberts, these Mailables are in Markdown, which then appears to be injected into an actual email 'theme' that's still in the tger/tger repo under `resources/views/vendor/mail `. Will need to figure out down the line on how to deal with this issue or if something should be done now.
